### PR TITLE
Fix WorldGuard hook, null-check movement event and case-insensitive command blocking

### DIFF
--- a/src/main/java/de/nikey/combatLog/CombatLog.java
+++ b/src/main/java/de/nikey/combatLog/CombatLog.java
@@ -14,8 +14,6 @@ import static de.nikey.combatLog.Listener.GeneralListener.combatTimers;
 
 public final class CombatLog extends JavaPlugin {
 
-    private static boolean worldGuardEnabled = false;
-
     @Override
     public void onEnable() {
         saveDefaultConfig();
@@ -26,7 +24,7 @@ public final class CombatLog extends JavaPlugin {
                 "LI8sodAD"
         ).checkForUpdates();
 
-        Metrics metrics = new Metrics(this,	28071);
+        new Metrics(this, 28071);
     }
 
     @Override
@@ -47,6 +45,6 @@ public final class CombatLog extends JavaPlugin {
 
 
     public static boolean isWorldGuardEnabled() {
-        return worldGuardEnabled;
+        return WorldGuardHook.isWorldGuardEnabled();
     }
 }

--- a/src/main/java/de/nikey/combatLog/Listener/GeneralListener.java
+++ b/src/main/java/de/nikey/combatLog/Listener/GeneralListener.java
@@ -200,6 +200,7 @@ public class GeneralListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerMoveIntoRegion(PlayerMoveEvent event) {
         if (!CombatLog.isWorldGuardEnabled()) return;
+        if (event.getTo() == null) return;
 
         Player player = event.getPlayer();
         if (!combatTimers.containsKey(player.getUniqueId())) return;
@@ -376,11 +377,16 @@ public class GeneralListener implements Listener {
 
         String[] args = event.getMessage().split(" ");
         String cmd = args[0].startsWith("/") ? args[0].substring(1) : args[0];
+        cmd = cmd.toLowerCase(java.util.Locale.ROOT);
 
         List<String> blocked = CombatLog.getPlugin(CombatLog.class).getConfig().getStringList("combat-log.blocked-commands");
         if (blocked.isEmpty()) return;
 
-        if (blocked.contains(cmd)) {
+        boolean isBlocked = blocked.stream()
+                .map(s -> s.toLowerCase(java.util.Locale.ROOT))
+                .anyMatch(cmd::equals);
+
+        if (isBlocked) {
             event.setCancelled(true);
             player.sendMessage(msg(
                     "combat-log.messages.blocked-command",


### PR DESCRIPTION
### Motivation
- Behebt ein Funktionsproblem, bei dem `CombatLog.isWorldGuardEnabled()` einen nie gesetzten lokalen Flag zurückgab und dadurch WorldGuard-Regionseintrittsschutz nicht korrekt greift.
- Verhindert mögliche NPEs bei ungewöhnlichen Move-Events durch Absicherung von `PlayerMoveEvent`.
- Erhöht Zuverlässigkeit der geblockten Befehle, indem der Vergleich gegen die Konfiguration case-insensitive gemacht wird.

### Description
- `src/main/java/de/nikey/combatLog/CombatLog.java`: Entfernt das unbenutzte lokale `worldGuardEnabled`-Flag, initialisiert `Metrics` direkt mit `new Metrics(this, 28071)` und lässt `isWorldGuardEnabled()` den Status aus `WorldGuardHook.isWorldGuardEnabled()` zurückgeben.
- `src/main/java/de/nikey/combatLog/Listener/GeneralListener.java`: Fügt in `onPlayerMoveIntoRegion` eine `if (event.getTo() == null) return;`-Prüfung hinzu, um Null-Zugriffe zu vermeiden.
- `src/main/java/de/nikey/combatLog/Listener/GeneralListener.java`: Normalisiert den eingegebenen Befehl mit `toLowerCase(Locale.ROOT)` und vergleicht gegen eine ebenfalls kleingeschriebene Version der konfigurierten `combat-log.blocked-commands`, sodass Befehle unabhängig von Groß-/Kleinschreibung erkannt werden.

### Testing
- Versucht gebaut mit `mvn -q -DskipTests package`, wobei der Build in dieser Umgebung aufgrund eines externen Abhängigkeitsauflösungsfehlers (Maven Central lieferte HTTP 403 für ein Plugin) nicht abgeschlossen werden konnte.
- Es wurden keine projekt-spezifischen Unit-Tests ausgeführt, da keine vorhanden sind und der Maven-Build fehlschlug.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeb54af6688321b988e0dcd7714a4e)